### PR TITLE
Enable the default path for packages without a main

### DIFF
--- a/package-name-map/src/package-name-map.ts
+++ b/package-name-map/src/package-name-map.ts
@@ -102,18 +102,10 @@ export class PackageNameMap {
       );
     }
 
-    // 6. If the specifier is to a sub-module, but the package doesn't have a
-    //    path, throw an error.
-    if (specifier !== packageName && pkg.path === undefined) {
-      throw new Error(
-        `Cannot resolve specifier, no path found for package ${packageName}`
-      );
-    }
-
-    // 7. Get the full path prefix of the scope containing the found package
+    // 6. Get the full path prefix of the scope containing the found package
     const packagePathPrefix = scopeContext[scopeContext.length - 1].prefixURL;
 
-    // 8. Compute package-relative path of the module.
+    // 7. Compute package-relative path of the module.
     //
     // If the specifier is fully "bare" (it's only a package name), then use
     // the Package's main file, otherwise remove the package name from the
@@ -123,7 +115,7 @@ export class PackageNameMap {
         ? pkg.main
         : specifier.substring(packageName!.length + 1);
 
-    // 9. Return the resolved URL built from: the baseURL, the scope's prefix,
+    // 8. Return the resolved URL built from: the baseURL, the scope's prefix,
     //    the package's path, and the package-relative path of the module.
     return resolveURL(
       this.baseURL,

--- a/package-name-map/src/test/package-name-map_test.ts
+++ b/package-name-map/src/test/package-name-map_test.ts
@@ -75,7 +75,7 @@ suite('PackageNameMap', () => {
               path: '/node_modules/@polymer/polymer-foo',
               main: 'polymer-foo.js',
             },
-          },
+          }
         },
         baseURL
       );
@@ -85,6 +85,10 @@ suite('PackageNameMap', () => {
           map.resolve('app', referrerURL),
           'http://foo.com/resources/app/src/index.js'
         );
+      });
+
+      test('uses the default path for a package with only a main', () => {
+        assert.equal(map.resolve('app/foo.js', referrerURL), 'http://foo.com/resources/app/foo.js');
       });
 
       test('resolves package name for a package with an absolute path and main', () => {
@@ -127,10 +131,6 @@ suite('PackageNameMap', () => {
           map.resolve('@polymer/polymer-foo', referrerURL),
           'http://foo.com/node_modules/@polymer/polymer-foo/polymer-foo.js'
         );
-      });
-
-      test('errors for a submodule with only a main', () => {
-        assert.throws(() => map.resolve('app/foo.js', referrerURL));
       });
     });
 


### PR DESCRIPTION
It seems a little inconsistent to apply the default path as the package name itself only when there is a main, when this approach can work just as well for submodules.

For example, this verbosity is already becoming clear in https://github.com/domenic/package-name-maps/compare/master...guybedford:package-name-path?expand=1#diff-a3199dd5a8438364bee42f2d6ffc3826R58.

This one thing will likely considerably simplify a lot of configurations in avoiding the need to use `path` entirely for most packages.