### PR TITLE
Throw resolving a package with no main

### DIFF
--- a/package-name-map/src/package-name-map.ts
+++ b/package-name-map/src/package-name-map.ts
@@ -21,7 +21,7 @@ export interface Scope {
 }
 
 export interface Package {
-  main: string;
+  main?: string;
   path?: string;
 }
 
@@ -146,6 +146,12 @@ export class PackageNameMap {
     // 6. Get the full path prefix of the scope containing the found package
     const packagePathPrefix = scopeContext[scopeContext.length - 1].prefixURL;
 
+    if (specifier === packageName && pkg.main === undefined) {
+      throw new Error(
+        `Cannot resolve specifier ${specifier}, no main found for package ${packageName}`
+      );
+    }
+
     // 7. Compute package-relative path of the module.
     //
     // If the specifier is fully "bare" (it's only a package name), then use
@@ -153,7 +159,7 @@ export class PackageNameMap {
     // specifier to get the package-internal path to the module.
     const packageRelativeModulePath =
       specifier === packageName
-        ? pkg.main
+        ? <string>pkg.main
         : specifier.substring(packageName!.length + 1);
 
     // 8. Return the resolved URL built from: the baseURL, the scope's prefix,

--- a/package-name-map/src/test/package-name-map_test.ts
+++ b/package-name-map/src/test/package-name-map_test.ts
@@ -146,6 +146,9 @@ suite('PackageNameMap', () => {
               path: 'lodash-es',
               main: 'lodash.js',
             },
+            'lodash-es': {
+              path: 'lodash-es'
+            },
             '@polymer/polymer': {
               path: '@polymer/polymer',
               main: 'polymer.js',
@@ -172,6 +175,23 @@ suite('PackageNameMap', () => {
       test('resolves a submodule for package with a path and main', () => {
         assert.equal(
           map.resolve('lodash/bar.js', referrerURL),
+          'http://foo.com/node_modules/lodash-es/bar.js'
+        );
+      });
+
+      test('throws resolving main for a package with only a path', () => {
+        try {
+          map.resolve('lodash-es', referrerURL);
+          assert.fail();
+        }
+        catch (err) {
+          assert.equal(err.message, 'Cannot resolve specifier lodash-es, no main found for package lodash-es');
+        }
+      });
+
+      test('resolves a submodule for a package with only a path', () => {
+        assert.equal(
+          map.resolve('lodash-es/bar.js', referrerURL),
           'http://foo.com/node_modules/lodash-es/bar.js'
         );
       });


### PR DESCRIPTION
This ensures we throw an error when resolving a package with a path but no main set, which wasn't previously tested.